### PR TITLE
Remove lc=FR from paypal form

### DIFF
--- a/community.mdwn
+++ b/community.mdwn
@@ -33,7 +33,6 @@ You can help by:
 <input type="hidden" name="no_note" value="1"> 
 <input type="hidden" name="currency_code" value="EUR"> 
 <input type="hidden" name="tax" value="0"> 
-<input type="hidden" name="lc" value="FR"> 
 <input type="hidden" name="bn" value="PP-DonationsBF"> 
 <input type="image" src="https://www.paypal.com/en_US/i/btn/btn_donate_SM.gif" border="0" name="submit" alt="PayPal - la solution de paiement en ligne la plus simple et la plus sécurisée !"> 
 <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1"> 

--- a/templates/page.tmpl
+++ b/templates/page.tmpl
@@ -119,7 +119,6 @@
 <input type="hidden" name="no_note" value="1">
 <input type="hidden" name="currency_code" value="EUR">
 <input type="hidden" name="tax" value="0">
-<input type="hidden" name="lc" value="FR">
 <input type="hidden" name="bn" value="PP-DonationsBF">
 <input type="image" src="https://www.paypal.com/en_US/i/btn/btn_donate_SM.gif" border="0" name="submit" alt="PayPal - la solution de paiement en ligne la plus simple et la plus sécurisée !">
 <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1">


### PR DESCRIPTION
A shot at https://github.com/awesomeWM/awesome-www/issues/5.

It still selects French for me.

Also the `alt` text needs to be fixed (to be English, and might determine that it auto-selects French still).
