### PR TITLE
Makefile: use original HOME with ldoc target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Make git not use user's config.
+OLD_HOME:=$(HOME)
 HOME:=/dev/null
 
 all: output ldoc changelogs manpages
@@ -18,7 +19,7 @@ authors.mdwn:
 	echo '</pre>' >> authors.mdwn
 ldoc:
 	rm -f src/build
-	make -C src build cmake ldoc
+	HOME=$(OLD_HOME) make -C src build cmake ldoc
 
 clean:
 	rm -rf .ikiwiki html


### PR DESCRIPTION
I was getting this error:

> Scanning dependencies of target ldoc
> make[5]: Leaving directory '/home/user/Vcs/awesome-www/src/.build-host.example.com-x86_64-pc-linux-gnu-6.1.1'
> make[5]: Entering directory '/home/user/Vcs/awesome-www/src/.build-host.example.com-x86_64-pc-linux-gnu-6.1.1'
> lua: cannot open /dev/null/Vcs/ldoc/ldoc.lua: Not a directory

With this custom `ldoc` wrapper:

> lua ~/Vcs/ldoc/ldoc.lua $*