### PR TITLE
Use complete URLs for old issues and wiki

### DIFF
--- a/templates/page.tmpl
+++ b/templates/page.tmpl
@@ -35,8 +35,8 @@
                 <li><a href="/community/">community</a></li>
                 <li><a href="/doc/">doc</a></li>
                 <li><a href="https://github.com/awesomeWM/awesome/issues">bugs/issues</a></li>
-                <li><a href="/bugs/">(old issues)</a></li>
-                <li><a href="/wiki/">wiki</a></li>
+                <li><a href="https://awesome.naquadah.org/bugs/">(old issues)</a></li>
+                <li><a href="https://awesome.naquadah.org/wiki/">wiki</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
This way the links will keep pointing to the old server even if we
redirect our server elsewhere.

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @blueyed 