### PR TITLE
Import all the old releases

### DIFF
--- a/download.mdwn
+++ b/download.mdwn
@@ -6,8 +6,8 @@ Latest stable version of **awesome** is version 3.5.9 (*Mighty Ravendark*)
 released on 6 March 2016.
 
 * [v3.5.9 changelog](/changelogs/v3.5.9) ([short](/changelogs/short/v3.5.9))
-* [awesome-3.5.9.tar.bz2](awesome-3.5.9.tar.bz2)
-* [awesome-3.5.9.tar.xz](awesome-3.5.9.tar.xz)
+* [awesome-3.5.9.tar.bz2](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-3.5.9.tar.bz2)
+* [awesome-3.5.9.tar.xz](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-3.5.9.tar.xz)
 
 ## Old stable
 
@@ -17,8 +17,8 @@ Latest old stable version of **awesome** is version 2.3.6 (*Tomorrow Morning*)
 released on 18th April 2009.
 
 * [v2.3.6 changelog](/changelogs/v2.3.6) ([short](/changelogs/short/v2.3.6))
-* [awesome-2.3.6.tar.gz](awesome-2.3.6.tar.gz)
-* [awesome-2.3.6.tar.bz2](awesome-2.3.6.tar.bz2)
+* [awesome-2.3.6.tar.gz](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-2.3.6.tar.gz)
+* [awesome-2.3.6.tar.bz2](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-2.3.6.tar.bz2)
 
 ## Development
 


### PR DESCRIPTION
What better way is there to bloat a git repository than importing binary
data? :-)

Fixes: #26
Signed-off-by: Uli Schlachter psychon@znc.in

Fun fact: First git push took 12 minutes. I screwed something up and had to re-do it. Second push finished in just 10 minutes! `du -sh download` says this commit is adding 58MB (or MiB? Dunno) of binary data.
