### PR TITLE
Change the appearance of the top-menu

### DIFF
--- a/local.css
+++ b/local.css
@@ -6,6 +6,7 @@
 
 
 body {
+	margin: 0px;
 	background: url(images/top_bg.gif);
 	background-repeat: repeat-x;
 	font-family: Verdana, Arial, sans-serif;
@@ -62,7 +63,7 @@ blockquote{
 #top {
 	font-size: 0.8em;
 	width: 100%;
-	height: 68px;
+	height: 88px;
 	color: #fff;
 	/*background: #000 url(images/top_bg.gif);*/
 	overflow:hidden;
@@ -113,7 +114,7 @@ blockquote{
 
 #menu li a {
 	display: block;
-	padding: 15px 10px 12px 10px;
+	padding: 20px 10px 50px 10px;
 	text-decoration: none;
 	color: #fff;
 	font-weight: bold;

--- a/local.css
+++ b/local.css
@@ -76,7 +76,7 @@ blockquote{
 	font-weight: bold;
 	position: relative;
 	margin: 0px;
-	top:33px;
+	top:25px;
 	display:block;
 	float:left;
 	background: url(images/bg_t.gif) no-repeat;
@@ -114,7 +114,7 @@ blockquote{
 
 #menu li a {
 	display: block;
-	padding: 20px 10px 50px 10px;
+	padding: 20px 15px 50px 15px;
 	text-decoration: none;
 	color: #fff;
 	font-weight: bold;


### PR DESCRIPTION
When you hover over one of the items in the top menu, e.g. "home", a
background appears. This commit changes this background to cover the
full height of the top-menu instead of only a small rectangle around the
item.

The "margin: 0px" is needed so that this background can "reach" up to
the top of the page. Note that this however also affects other elements
on the page and now the "awesome" at the top left of the page is a bit
farther up.

The height of "#top" and the padding around the links then change the
actual height of this background.

This is partial revert of 34c806d8176a87398e2372.

Signed-off-by: Uli Schlachter <psychon@znc.in>

For me locally, before (top) and after (bottom) (yes, I don' t have perlmagick installed; i know):

![before2](https://cloud.githubusercontent.com/assets/89482/21466203/ef2a4bd2-c9c0-11e6-83d3-2101f6e57a81.png)
![after2](https://cloud.githubusercontent.com/assets/89482/21466204/f5184ca6-c9c0-11e6-8209-1f24b7ca0ca5.png)



