### PR TITLE
.travis.yml: Use --no-pager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,6 @@ after_success:
       git config user.email "awesome-robot@users.noreply.github.com"
       git add --all .
       git commit -m "Update from Travis for awesome-www@${commit_hash}"
-      git show --stat
+      git --no-pager show --stat
       git push origin "$(git symbolic-ref --quiet HEAD)" 2>&1 | sed "s/$GH_APIDOC_TOKEN/GH_APIDOC_TOKEN/g"
     fi


### PR DESCRIPTION
Signed-off-by: Uli Schlachter <psychon@znc.in>

The build after merging #38 failed: https://travis-ci.org/awesomeWM/awesome-www/builds/186631479
It looks like `git show --stat` started a pager and then Travis eventually terminated the build. This is just a theory, but using `--no-pager` won't hurt.

Edit: I guess `dist: trusty` brought a newer git and that's what eventually caused this?