### PR TITLE
Add .txt extenstion to changelogs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ changelogs:
 	git --git-dir=src/.git tag | grep -v rc | sort -n | \
 	    (while read v; do \
 	    test -z "$$pv" && pv="`git --git-dir=src/.git rev-list HEAD | tail -n1`" ; \
-	    git --git-dir=src/.git shortlog --no-merges $$pv..$$v > html/changelogs/short/$$v ; \
-	    git --git-dir=src/.git log --no-merges $$pv..$$v > html/changelogs/$$v ; \
+	    git --git-dir=src/.git shortlog --no-merges $$pv..$$v > html/changelogs/short/$$v.txt ; \
+	    git --git-dir=src/.git log --no-merges $$pv..$$v > html/changelogs/$$v.txt ; \
 	    pv=$$v; done)
 
 manpages:

--- a/download.mdwn
+++ b/download.mdwn
@@ -5,7 +5,7 @@
 Latest stable version of **awesome** is version 4.0 (*Harder, Better, Faster,
 Stronger*) released on 25 December 2016.
 
-* [v4.0 changelog](../changelogs/v4.0) ([short](../changelogs/short/v4.0))
+* [v4.0 changelog](../changelogs/v4.0.txt) ([short](../changelogs/short/v4.0.txt))
 * [awesome-4.0.tar.bz2](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.0.tar.bz2) ([GPG sig](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.0.tar.bz2.asc))
 * [awesome-4.0.tar.xz](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.0.tar.xz) ([GPG sig](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.0.tar.xz.asc))
 
@@ -16,7 +16,7 @@ This branch of **awesome** is deprecated.
 Latest old stable version of **awesome** is version 3.5.9 (*Mighty Ravendark*)
 released on 6 March 2016.
 
-* [v3.5.9 changelog](../changelogs/v3.5.9) ([short](../changelogs/short/v3.5.9))
+* [v3.5.9 changelog](../changelogs/v3.5.9.txt) ([short](../changelogs/short/v3.5.9.txt))
 * [awesome-3.5.9.tar.bz2](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-3.5.9.tar.bz2)
 * [awesome-3.5.9.tar.xz](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-3.5.9.tar.xz)
 


### PR DESCRIPTION
This is required for GitHub pages to use a proper mime type.

Fixes https://github.com/awesomeWM/awesome-www/issues/51.