### PR TITLE
Fixing wrong Markdown from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ open `index.html` when following a link to a directory:
 ## Contributing to the Screenshots Section
 
 To contribute with Screenshots:
+
 1. Add your image to the folder images/screenshots with an appropiated name.
-2. Add a new <figure> tag in the bottom of *screenshots.mdwn*,
-3. Inside the new tag, add the screenshots with a <img> tag and use the <figcaption> to add caption to the image, explaining what is being used on the screenshot.
+
+2. Add a new `<figure>` tag in the bottom of *screenshots.mdwn*,
+
+3. Inside the new tag, add the screenshots with a <img> tag and use the `<figcaption>` to add caption to the image, explaining what is being used on the screenshot.
 
 ## Contributing to Recipes Section
 


### PR DESCRIPTION
There were some spacing mistakes in the Screenshot contributing section from README, those mistakes has been fixed here. 