### PR TITLE
menu: remove direct link to apidoc, shorten "doc"

### DIFF
--- a/templates/page.tmpl
+++ b/templates/page.tmpl
@@ -30,8 +30,7 @@
             <li class="menu-community"><a href="<TMPL_VAR BASEURL>community/">community</a></li>
             <li class="menu-recipes"><a href="<TMPL_VAR BASEURL>recipes/">recipes</a></li>
             <li class="menu-screenshots"><a href="<TMPL_VAR BASEURL>screenshots/">screenshots</a></li>
-            <li class="menu-doc-git"><a href="<TMPL_VAR BASEURL>apidoc/">doc (git/master)</a></li>
-            <li class="menu-doc"><a href="<TMPL_VAR BASEURL>doc/">doc (v4.0)</a></li>
+            <li class="menu-doc"><a href="<TMPL_VAR BASEURL>doc/">doc</a></li>
             <li class="menu-issues"><a href="https://github.com/awesomeWM/awesome/issues">bugs/issues</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Ref: https://github.com/awesomeWM/awesome-www/issues/64