### PR TITLE
Fix "fix xrandr.lua link"

### DIFF
--- a/recipes/xrandr.mdwn
+++ b/recipes/xrandr.mdwn
@@ -5,7 +5,7 @@ Using this snippet you can set a keybinding where you swap to all possible arran
 
 The process of setting up this script goes as follow:
 
-1. Create a file called `xrandr.lua` in your file system (preferably in awesome's folder) with the [script](../xrandr.lua) content.
+1. Create a file called `xrandr.lua` in your file system (preferably in awesome's folder) with the [[script|xrandr.lua]] content.
 
 2. Import the script in your `rc.lua`
 


### PR DESCRIPTION
It is my understanding that [title](target) is meant for external links
while [[title|target]] does internal links. The main difference here is
that ikiwiki automatically finds the target and makes it work with its
directory structure, so that no "manual ../" is needed.

This amends/fixes commit f9e7311e.

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @aajjbb @blueyed Just FYI. (Also, I think it's a bit easier to understand this way).

Oh and according to `diff`, the generated html stays the same.