### PR TITLE
Making xrandr.lua cycle through states

### DIFF
--- a/recipes/xrandr.lua
+++ b/recipes/xrandr.lua
@@ -5,7 +5,7 @@ local naughty   = require("naughty")
 local beautiful = require("beautiful");
 
 -- A path to a fancy icon
-local icon_path = "";
+local icon_path = ""
 
 -- Get active outputs
 local function outputs()
@@ -91,8 +91,7 @@ local function menu()
 end
 
 -- Display xrandr notifications from choices
-local state = { iterator = nil,
-                timer = nil,
+local state = { timer = nil,
                 cid = nil }
 local function xrandr()
    -- Stop any previous timer
@@ -114,7 +113,7 @@ local function xrandr()
 
    if not next then
       label, icon = "Keep the current configuration", icon_path
-      state.iterator = nil
+      state.index = nil
    else
       label, action, icon = unpack(next)
    end
@@ -130,8 +129,7 @@ local function xrandr()
    state.timer:connect_signal("timeout",
                               function()
                                  state.timer:stop()
-                                 state.timer = nil
-                                 state.iterator = nil
+                                 state.index = nil
                                  if action then
                                     awful.util.spawn(action, false)
                                  end


### PR DESCRIPTION
The last changes on the iteration process made `xrandr.lua` not cycle through screen configurations. This PR fixes it.