### PR TITLE
More XrandR changes

### DIFF
--- a/recipes/xrandr.lua
+++ b/recipes/xrandr.lua
@@ -81,9 +81,7 @@ local function menu()
          end
       end
 
-      menu[#menu + 1] = { label,
-                          cmd,
-                          icon_path}
+      menu[#menu + 1] = { label, cmd }
    end
 
    return menu
@@ -106,18 +104,18 @@ local function xrandr()
    end
 
    -- Select one and display the appropriate notification
-   local label, action, icon
+   local label, action
    local next  = state.menu[state.index]
    state.index = state.index + 1
 
    if not next then
-      label, icon = "Keep the current configuration", icon_path
+      label = "Keep the current configuration"
       state.index = nil
    else
-      label, action, icon = unpack(next)
+      label, action = unpack(next)
    end
    state.cid = naughty.notify({ text = label,
-                                icon = icon,
+                                icon = icon_path,
                                 timeout = 4,
                                 screen = mouse.screen,
                                 replaces_id = state.cid }).id

--- a/recipes/xrandr.lua
+++ b/recipes/xrandr.lua
@@ -2,7 +2,6 @@
 
 local awful     = require("awful")
 local naughty   = require("naughty")
-local beautiful = require("beautiful");
 
 -- A path to a fancy icon
 local icon_path = ""
@@ -121,7 +120,6 @@ local function xrandr()
                                 icon = icon,
                                 timeout = 4,
                                 screen = mouse.screen,
-                                font = beautiful.font,
                                 replaces_id = state.cid }).id
 
    -- Setup the timer


### PR DESCRIPTION
This removes some useless font and icon shuffling and uses naughty's destroy callback instead of having its own timer to do this. This has a behaviour change: If you click on the naughty notification, the change is not applied and you stay with the current configuration. Only if you let this actually expire does it apply the change.