### PR TITLE
Add a README.md to the generated web page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ all: output ldoc changelogs manpages
 output:
 	ikiwiki $(CURDIR) html -v --wikiname about --plugin=goodstuff \
 	  --templatedir=templates \
-	  --exclude=html --exclude=Makefile --exclude=README.md
+	  --exclude=html --exclude=Makefile --exclude=README.md \
+	  --exclude=README.for_webpage.md
 	echo awesomewm.org > html/CNAME
+	cp README.for_webpage.md html/README.md
 
 ldoc:
 	rm -f src/build

--- a/README.for_webpage.md
+++ b/README.for_webpage.md
@@ -1,0 +1,6 @@
+# DO NOT EDIT
+
+This repository contains the generated version of the web page for the [awesome
+window manager](https://awesomewm.org/). All pull requests to this repository
+will be ignored. Instead, please send suggestions for changes to the
+[awesome-www repository](https://github.com/awesomeWM/awesome-www) instead.


### PR DESCRIPTION
Fixes: https://github.com/awesomeWM/awesomeWM.github.io/issues/4
Signed-off-by: Uli Schlachter <psychon@znc.in>

The generated README should look as follows: https://github.com/psychon/awesome-www/blob/4b23d5fb1484ddf29942390990c6aa904dbd8dc2/README.for_webpage.md

Edit: I just found https://github.com/awesomeWM/awesomeWM.github.io/pull/2/commits/a48ba66a0d4ebcf2bab240b1eb730aeac94b76a5. Is that README better than mine?