### PR TITLE
Recommend using distro packages

### DIFF
--- a/download.mdwn
+++ b/download.mdwn
@@ -1,5 +1,32 @@
 # Download
 
+## Packages
+
+**awesome** is currently available in:
+
+* Arch Linux:
+  * stable: [x86\_64](https://www.archlinux.org/packages/community/x86_64/awesome/)
+    / [i686](https://www.archlinux.org/packages/community/i686/awesome/)
+  * [awesome-git in AUR](https://aur.archlinux.org/packages/awesome-git)
+  * [awesome-luajit-git in AUR](https://aur.archlinux.org/packages/awesome-luajit-git/)
+* [Debian](http://packages.debian.org/awesome)
+* [Ubuntu](http://packages.ubuntu.com/awesome)
+* [FreeBSD](http://www.freshports.org/x11-wm/awesome/)
+* [Gentoo](http://packages.gentoo.org/package/x11-wm/awesome)
+* [OpenBSD](http://openports.se/x11/awesome)
+* [NetBSD](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/wm/awesome/)
+* [Source Mage GNU/Linux](http://codex.sourcemage.org/test/windowmanagers/awesome/)
+* [T2 SDE](http://t2-project.org/packages/awesome.html)
+* [CRUX](http://crux.nu/portdb/index.php?q=awesome&a=search&s=true)
+* [openSUSE](http://download.opensuse.org/repositories/X11:/windowmanagers/)
+* [PLD Linux](http://pld-linux.org)
+* [Mageia](http://mageia.madb.org/package/show/application/0/name/awesome)
+* [OpenIndiana](http://pkg.openindiana.org/hipster/en/search.shtml?token=awesome&action=Search)
+
+### Distributions using Awesome as the default window manager
+
+ * [GoboLinux](gobolinux.org)
+
 ## Stable
 
 Latest stable version of **awesome** is version 4.1 (*Technologic*)
@@ -32,30 +59,3 @@ Alternatively, development versions can be downloaded as ZIP files through the
 ## History
 
 A list of of old releases [[is available here|releases]].
-
-## Packages
-
-**awesome** is currently available in:
-
-* Arch Linux:
-  * stable: [x86\_64](https://www.archlinux.org/packages/community/x86_64/awesome/)
-    / [i686](https://www.archlinux.org/packages/community/i686/awesome/)
-  * [awesome-git in AUR](https://aur.archlinux.org/packages/awesome-git)
-  * [awesome-luajit-git in AUR](https://aur.archlinux.org/packages/awesome-luajit-git/)
-* [Debian](http://packages.debian.org/awesome)
-* [Ubuntu](http://packages.ubuntu.com/awesome)
-* [FreeBSD](http://www.freshports.org/x11-wm/awesome/)
-* [Gentoo](http://packages.gentoo.org/package/x11-wm/awesome)
-* [OpenBSD](http://openports.se/x11/awesome)
-* [NetBSD](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/wm/awesome/)
-* [Source Mage GNU/Linux](http://codex.sourcemage.org/test/windowmanagers/awesome/)
-* [T2 SDE](http://t2-project.org/packages/awesome.html)
-* [CRUX](http://crux.nu/portdb/index.php?q=awesome&a=search&s=true)
-* [openSUSE](http://download.opensuse.org/repositories/X11:/windowmanagers/)
-* [PLD Linux](http://pld-linux.org)
-* [Mageia](http://mageia.madb.org/package/show/application/0/name/awesome)
-* [OpenIndiana](http://pkg.openindiana.org/hipster/en/search.shtml?token=awesome&action=Search)
-
-### Distributions using Awesome as the default window manager
-
- * [GoboLinux](gobolinux.org)

--- a/download.mdwn
+++ b/download.mdwn
@@ -27,7 +27,23 @@
 
  * [GoboLinux](gobolinux.org)
 
-## Stable
+## Building from Source
+
+<p class="standout">
+We strongly recommend using the awesome package of your distribution.
+</p>
+
+This is because many people who tried to build from source had problems.
+[LGI](https://github.com/pavouk/lgi), one of awesome's dependencies, currently
+hardcodes the package search path used by Lua 5.1. Part of the reason for this
+is that Lua upstream intends Lua to be embedded, which means that detecting an
+installed Lua version properly is not easy.
+
+After installing awesome, you can check if you are affected by this problem by
+running `awesome -v`. If an error message is displayed instead of LGI version's
+number, you are likely affected.
+
+### Stable
 
 Latest stable version of **awesome** is version 4.1 (*Technologic*)
 released on 18 March 2017.
@@ -36,7 +52,7 @@ released on 18 March 2017.
 * [awesome-4.1.tar.bz2](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.1.tar.bz2) ([GPG sig](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.1.tar.bz2.asc))
 * [awesome-4.1.tar.xz](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.1.tar.xz) ([GPG sig](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-4.1.tar.xz.asc))
 
-## Old stable
+### Old stable
 
 This branch of **awesome** is deprecated.
 
@@ -47,7 +63,7 @@ released on 6 March 2016.
 * [awesome-3.5.9.tar.bz2](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-3.5.9.tar.bz2)
 * [awesome-3.5.9.tar.xz](https://github.com/awesomeWM/awesome-releases/raw/master/awesome-3.5.9.tar.xz)
 
-## Development
+### Development
 
 The Git repository can be cloned from Github:
 


### PR DESCRIPTION
See the recent problems with broken LGI installations for reasons why.

CC @Elv13 @blueyed 

----

Another (additional) idea: i3 offers a repository for debian and ubuntu with their latest version: http://i3wm.org/docs/repositories.html
I did not look too closely yet, but these images [seem to be built on travis](https://github.com/i3/i3/blob/86ad867277b0de63537720ec49ca6523707660cb/.travis.yml#L38-L41) and then [deployed to bintray](https://github.com/i3/i3/blob/86ad867277b0de63537720ec49ca6523707660cb/.travis.yml#L46-L62) (whatever that is...).

We could do the same thing, but might have to ship packages for more than just awesome. Currently for Travis on [Ubuntu Trusty](https://github.com/awesomeWM/awesome-www/blob/master/.travis.yml#L1) we "just" need [libxcb-cursor-dev, xcb-util-xrm and lgi](https://github.com/awesomeWM/awesome-www/blob/master/.travis.yml#L67-L82) (ldoc is not a run-time dependency).

CC @AirBlader just in case there's something to add.

(Yes, I know that I should feel bad for (ab)using a pull request for a discussion that rather belongs into an issue. No, I do not actually feel bad.)