### PR TITLE
Add Pulseaudio, Connman and Battery to Widgets recipes

### DIFF
--- a/recipes.mdwn
+++ b/recipes.mdwn
@@ -16,6 +16,7 @@ to improve your Awesome setup.
 * [[Countdown|recipes/countdown]]
 * [[MPD current song|recipes/mpc]]
 * [[Watchers|recipes/watch]]
+* [PulseAudio](https://github.com/stefano-m/awesome-pulseaudio_widget)
 
 ## Libraries
 

--- a/recipes.mdwn
+++ b/recipes.mdwn
@@ -18,6 +18,7 @@ to improve your Awesome setup.
 * [[Watchers|recipes/watch]]
 * [PulseAudio](https://github.com/stefano-m/awesome-pulseaudio_widget)
 * [Connman (network manager)](https://github.com/stefano-m/awesome-connman_widget)
+* [Battery Indicator (UPower)](https://github.com/stefano-m/awesome-power_widget)
 
 ## Libraries
 

--- a/recipes.mdwn
+++ b/recipes.mdwn
@@ -17,6 +17,7 @@ to improve your Awesome setup.
 * [[MPD current song|recipes/mpc]]
 * [[Watchers|recipes/watch]]
 * [PulseAudio](https://github.com/stefano-m/awesome-pulseaudio_widget)
+* [Connman (network manager)](https://github.com/stefano-m/awesome-connman_widget)
 
 ## Libraries
 


### PR DESCRIPTION
@psychon suggested in https://github.com/stefano-m/awesome-pulseaudio_widget/issues/1#issue-241511660 that I add my PulseAudio widget to the recipes page.

I have also added two more widgets written by me: Connman network manager and Battery Indicator (uses UPower).

All widgets are available from [my luarocks.org modules](http://luarocks.org/modules/stefano-m) too.