### PR TITLE
download: Fix GoboLinux link

### DIFF
--- a/download.mdwn
+++ b/download.mdwn
@@ -26,7 +26,7 @@
 
 ### Distributions using Awesome as the default window manager
 
- * [GoboLinux](gobolinux.org)
+ * [GoboLinux](https://gobolinux.org)
 
 ## Building from Source
 


### PR DESCRIPTION
Just linking to gobolinux.org without `https://` brung up a 404. This PR fixes that :P