### PR TITLE
Recipes: add .luacheckrc symlink

### DIFF
--- a/recipes/.luacheckrc
+++ b/recipes/.luacheckrc
@@ -1,0 +1,1 @@
+../src/.luacheckrc


### PR DESCRIPTION
This uses awesome's .luacheckrc for recipes also.

In the long run we might want to enforce luacheck for recipes, but
currently there are quite some issues still.

```
% luacheck recipes
Checking recipes/gpmdp.lua                        28 warnings

    recipes/gpmdp.lua:21:21: accessing undefined variable dpi
    recipes/gpmdp.lua:34:91: unused argument stdout
    recipes/gpmdp.lua:71:5: setting non-standard global variable gpm_now
    recipes/gpmdp.lua:74:9: mutating non-standard global variable gpm_now
    recipes/gpmdp.lua:75:9: mutating non-standard global variable gpm_now
    recipes/gpmdp.lua:77:9: setting non-standard global variable dict
    recipes/gpmdp.lua:77:15: setting non-standard global variable pos
    recipes/gpmdp.lua:77:20: setting non-standard global variable err
    recipes/gpmdp.lua:79:9: mutating non-standard global variable gpm_now
    recipes/gpmdp.lua:79:29: accessing undefined variable dict
    recipes/gpmdp.lua:80:9: mutating non-standard global variable gpm_now
    recipes/gpmdp.lua:80:29: accessing undefined variable dict
    recipes/gpmdp.lua:81:9: mutating non-standard global variable gpm_now
    recipes/gpmdp.lua:81:29: accessing undefined variable dict
    recipes/gpmdp.lua:82:9: mutating non-standard global variable gpm_now
    recipes/gpmdp.lua:82:29: accessing undefined variable dict
    recipes/gpmdp.lua:83:9: mutating non-standard global variable gpm_now
    recipes/gpmdp.lua:83:29: accessing undefined variable dict
    recipes/gpmdp.lua:85:20: accessing undefined variable gpm_now
    recipes/gpmdp.lua:88:5: mutating non-standard global variable gpmdp_notification_preset
    recipes/gpmdp.lua:88:68: accessing undefined variable gpm_now
    recipes/gpmdp.lua:88:84: accessing undefined variable gpm_now
    recipes/gpmdp.lua:88:99: accessing undefined variable gpm_now
    recipes/gpmdp.lua:89:21: accessing undefined variable gpm_now
    recipes/gpmdp.lua:89:48: accessing undefined variable gpm_now
    recipes/gpmdp.lua:91:8: accessing undefined variable gpm_now
    recipes/gpmdp.lua:92:37: accessing undefined variable gpm_now
    recipes/gpmdp.lua:95:16: accessing undefined variable gpm_now

Checking recipes/mpc.lua                          3 warnings

    recipes/mpc.lua:77:16: shadowing upvalue err on line 55
    recipes/mpc.lua:145:30: unused argument success
    recipes/mpc.lua:187:31: unused argument success

Checking recipes/xrandr.lua                       6 warnings

    recipes/xrandr.lua:11:10: shadowing upvalue outputs on line 10
    recipes/xrandr.lua:32:8: unused loop variable i
    recipes/xrandr.lua:54:10: shadowing upvalue menu on line 53
    recipes/xrandr.lua:112:17: variable action is never accessed
    recipes/xrandr.lua:120:23: accessing undefined variable unpack
    recipes/xrandr.lua:125:42: accessing undefined variable mouse

Total: 37 warnings / 0 errors in 3 files
```