### PR TITLE
Grammar fixes

### DIFF
--- a/index.mdwn
+++ b/index.mdwn
@@ -49,7 +49,7 @@ window manager.
 
 * Very stable, fast and small codebase and footprint.
 * First window manager using asynchronous [XCB](http://xcb.freedesktop.org)
-  library instead of the old synchronous.
+  library instead of the old, synchronous
   [Xlib](http://en.wikipedia.org/wiki/Xlib), which make **awesome** less
   subject to latency compared to other window managers.
 * Documented source code and API.

--- a/index.mdwn
+++ b/index.mdwn
@@ -50,7 +50,7 @@ window manager.
 * Very stable, fast and small codebase and footprint.
 * First window manager using asynchronous [XCB](http://xcb.freedesktop.org)
   library instead of the old, synchronous
-  [Xlib](http://en.wikipedia.org/wiki/Xlib), which make **awesome** less
+  [Xlib](http://en.wikipedia.org/wiki/Xlib), which makes **awesome** less
   subject to latency compared to other window managers.
 * Documented source code and API.
 * No mouse needed: everything can be performed with keyboard.


### PR DESCRIPTION
Remove accidental period and separate consecutive adjectives with comma