### PR TITLE
Add Caps Lock and Calendar widgets to recipe list

### DIFF
--- a/recipes.mdwn
+++ b/recipes.mdwn
@@ -20,6 +20,8 @@ to improve your Awesome setup.
 * [Connman (network manager)](https://github.com/stefano-m/awesome-connman_widget)
 * [Battery Indicator (UPower)](https://github.com/stefano-m/awesome-power_widget)
 * [[Google Play Music Desktop Player|recipes/gpmdp]]
+* [[Caps Lock Indicator](https://github.com/stefano-m/awesome-capslock_widget)]
+* [[Calendar Widget](https://github.com/stefano-m/awesome-calendar_widget)]
 
 ## Libraries
 


### PR DESCRIPTION
I have written a couple of widgets to

1. display the Caps Lock status
2. embed the a calendar in the textclock widget

Maybe they are of interest and could be added to the recipe list.

Thanks.