### PR TITLE
Fix code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ To view it, open `html/index.html` in your web browser.
 You can simulate running a web server using Python, which will automatically
 open `index.html` when following a link to a directory:
 
-    cd html && python3 -m http.server -b localhost 8000 &
+```
+cd html && python3 -m http.server -b localhost 8000 &
+```
 
 ## Contributing to the Screenshots Section
 


### PR DESCRIPTION
mdl complained about it:

README.md:24: MD046 Code block style
A detailed description of the rules is available at
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md

Signed-off-by: Uli Schlachter <psychon@znc.in>