### PR TITLE
recipes: add modalawesome

### DIFF
--- a/recipes.mdwn
+++ b/recipes.mdwn
@@ -41,6 +41,7 @@ to improve your Awesome setup.
 * [Repetitive dynamic keybindings and macros](https://github.com/Elv13/repetitive)
 * [layout-machi - a manual layout with interactive editing](https://github.com/xinhaoyuan/layout-machi)
 * [nice - macOS-like seamless window decorations](https://github.com/mut-ex/awesome-wm-nice)
+* [modalawesome - framework for modal, vi-like keybindings](https://github.com/potamides/modalawesome)
 
 ## Others
 


### PR DESCRIPTION
I'd like to add [modalawesome](https://github.com/potamides/modalawesome), a framework for modal, vi-like keybindings,  to the recipes section. I think the exposure on the website could be of interest to some awesome users, who also like modal editors. Here is a short excerpt from the projects README:

>Modalawesome makes it possible to create vi-like keybindings for the [awesome window manager](https://awesomewm.org/). It introduces a modal alternative to the standard [awful.key](https://awesomewm.org/doc/api/libraries/awful.key.html) keybindings and supports complex commands with motions and counts by making use of Lua [patterns](https://www.lua.org/manual/5.3/manual.html#6.4.1). Check out the [demo](https://v.redd.it/e4pzh8l53df51/DASH_1080.mp4) to get an overall impression of what this is capable of.

