### PR TITLE
Fix broken Fedora package link

### DIFF
--- a/download.mdwn
+++ b/download.mdwn
@@ -10,7 +10,7 @@
   * [awesome-luajit-git in AUR](https://aur.archlinux.org/packages/awesome-luajit-git/)
 * [Debian](http://packages.debian.org/awesome)
 * [Ubuntu](http://packages.ubuntu.com/awesome)
-* [Fedora](https://apps.fedoraproject.org/packages/awesome)
+* [Fedora](https://packages.fedoraproject.org/pkgs/awesome/awesome/)
 * [FreeBSD](http://www.freshports.org/x11-wm/awesome/)
 * [Gentoo](http://packages.gentoo.org/package/x11-wm/awesome)
 * [OpenBSD](http://openports.se/x11/awesome)


### PR DESCRIPTION
Replace broken (returns HTTP 404) Fedora package download link:
https://apps.fedoraproject.org/packages/awesome

with:
https://packages.fedoraproject.org/pkgs/awesome/awesome/.